### PR TITLE
Make sure metrics are being sent before the context is shutdown

### DIFF
--- a/src/main/scala/org/apache/spark/groupon/metrics/MetricsReceiver.scala
+++ b/src/main/scala/org/apache/spark/groupon/metrics/MetricsReceiver.scala
@@ -109,7 +109,9 @@ private[metrics] class MetricsReceiver(val sparkContext: SparkContext,
         lastGaugeValues.put(metricName, value)
         getOrCreateGauge(metricName)
       }
-      case message: Any => throw new SparkException(s"$self does not implement 'receive' for message: $message")
+      case message: Any => context.sendFailure(
+        new SparkException(s"$self does not implement 'receive' for message: $message")
+      )
   }
 
   def getOrCreateCounter(metricName: String): Counter = {

--- a/src/main/scala/org/apache/spark/groupon/metrics/MetricsReceiver.scala
+++ b/src/main/scala/org/apache/spark/groupon/metrics/MetricsReceiver.scala
@@ -37,7 +37,7 @@ import java.util.concurrent.TimeUnit
 
 import com.codahale.metrics.{Clock, Counter, Gauge, Histogram, Meter, Metric, MetricRegistry, Reservoir, Timer}
 import org.apache.spark.{SparkContext, SparkException}
-import org.apache.spark.rpc.RpcEndpoint
+import org.apache.spark.rpc.{RpcCallContext, RpcEndpoint}
 
 import scala.collection.concurrent
 import scala.collection.JavaConverters.mapAsScalaConcurrentMapConverter
@@ -92,24 +92,24 @@ private[metrics] class MetricsReceiver(val sparkContext: SparkContext,
    * Performs the appropriate update operations on the [[Metric]] instances. If a `metricName` is seen for the first
    * time, a [[Metric]] instance is created using the data from the [[MetricMessage]].
    */
-  override def receive: PartialFunction[Any, Unit] = {
-    case CounterMessage(metricName, value) => {
-      getOrCreateCounter(metricName).inc(value)
-    }
-    case HistogramMessage(metricName, value, reservoirClass) => {
-      getOrCreateHistogram(metricName, reservoirClass).update(value)
-    }
-    case MeterMessage(metricName, value) => {
-      getOrCreateMeter(metricName).mark(value)
-    }
-    case TimerMessage(metricName, value, reservoirClass, clockClass) => {
-      getOrCreateTimer(metricName, reservoirClass, clockClass).update(value, MetricsReceiver.DefaultTimeUnit)
-    }
-    case GaugeMessage(metricName, value) => {
-      lastGaugeValues.put(metricName, value)
-      getOrCreateGauge(metricName)
-    }
-    case message: Any => throw new SparkException(s"$self does not implement 'receive' for message: $message")
+  override def receiveAndReply(context: RpcCallContext): PartialFunction[Any, Unit] = {
+      case CounterMessage(metricName, value) => {
+        getOrCreateCounter(metricName).inc(value)
+      }
+      case HistogramMessage(metricName, value, reservoirClass) => {
+        getOrCreateHistogram(metricName, reservoirClass).update(value)
+      }
+      case MeterMessage(metricName, value) => {
+        getOrCreateMeter(metricName).mark(value)
+      }
+      case TimerMessage(metricName, value, reservoirClass, clockClass) => {
+        getOrCreateTimer(metricName, reservoirClass, clockClass).update(value, MetricsReceiver.DefaultTimeUnit)
+      }
+      case GaugeMessage(metricName, value) => {
+        lastGaugeValues.put(metricName, value)
+        getOrCreateGauge(metricName)
+      }
+      case message: Any => throw new SparkException(s"$self does not implement 'receive' for message: $message")
   }
 
   def getOrCreateCounter(metricName: String): Counter = {

--- a/src/main/scala/org/apache/spark/groupon/metrics/MetricsReceiver.scala
+++ b/src/main/scala/org/apache/spark/groupon/metrics/MetricsReceiver.scala
@@ -95,20 +95,26 @@ private[metrics] class MetricsReceiver(val sparkContext: SparkContext,
   override def receiveAndReply(context: RpcCallContext): PartialFunction[Any, Unit] = {
       case CounterMessage(metricName, value) => {
         getOrCreateCounter(metricName).inc(value)
+        context.reply(true)
       }
       case HistogramMessage(metricName, value, reservoirClass) => {
         getOrCreateHistogram(metricName, reservoirClass).update(value)
+        context.reply(true)
       }
       case MeterMessage(metricName, value) => {
         getOrCreateMeter(metricName).mark(value)
+        context.reply(true)
       }
       case TimerMessage(metricName, value, reservoirClass, clockClass) => {
         getOrCreateTimer(metricName, reservoirClass, clockClass).update(value, MetricsReceiver.DefaultTimeUnit)
+        context.reply(true)
       }
       case GaugeMessage(metricName, value) => {
         lastGaugeValues.put(metricName, value)
         getOrCreateGauge(metricName)
+        context.reply(true)
       }
+
       case message: Any => context.sendFailure(
         new SparkException(s"$self does not implement 'receive' for message: $message")
       )

--- a/src/main/scala/org/apache/spark/groupon/metrics/SparkMetric.scala
+++ b/src/main/scala/org/apache/spark/groupon/metrics/SparkMetric.scala
@@ -35,9 +35,11 @@ package org.apache.spark.groupon.metrics
 import java.io.Closeable
 import java.util.concurrent.TimeUnit
 
-import com.codahale.metrics.{Clock, Reservoir, Metric}
+import com.codahale.metrics.{Clock, Metric, Reservoir}
 import com.codahale.metrics.{ExponentiallyDecayingReservoir, SlidingTimeWindowReservoir, SlidingWindowReservoir, UniformReservoir}
 import org.apache.spark.rpc.RpcEndpointRef
+
+import scala.concurrent.Future
 
 /**
  * SparkMetric instances implement APIs that look like their Codahale counterparts, but do not store any state. Instead,
@@ -51,7 +53,7 @@ sealed trait SparkMetric extends Metric with Serializable {
    * @param message [[MetricMessage]] to send
    */
   def sendMetric(message: MetricMessage): Unit = {
-    metricsEndpoint.send(message)
+    metricsEndpoint.askWithRetry[Any](message)
   }
 }
 

--- a/src/test/scala/org/apache/spark/groupon/metrics/MetricsReceiverTest.scala
+++ b/src/test/scala/org/apache/spark/groupon/metrics/MetricsReceiverTest.scala
@@ -119,14 +119,14 @@ class MetricsReceiverTest extends FlatSpec with Matchers with BeforeAndAfter wit
   "receive" should "handle CounterMessage correctly" in {
     val counterName = "Counter"
     val counterMessage = CounterMessage(counterName, 1)
-    metricsReceiver.self.send(counterMessage)
+    metricsReceiver.self.askWithRetry(counterMessage)
 
     eventually {
       metricsReceiver.metrics should contain key counterName
       metricsReceiver.metrics.get(counterName).get.asInstanceOf[Counter].getCount shouldBe 1
     }
 
-    metricsReceiver.self.send(counterMessage)
+    metricsReceiver.self.askWithRetry(counterMessage)
 
     eventually {
       metricsReceiver.metrics.get(counterName).get.asInstanceOf[Counter].getCount shouldBe 2
@@ -136,14 +136,14 @@ class MetricsReceiverTest extends FlatSpec with Matchers with BeforeAndAfter wit
   it should "handle HistogramMessage correctly" in {
     val histogramName = "Histogram"
     val histogramMessage = HistogramMessage(histogramName, 1, ReservoirClass.ExponentiallyDecaying)
-    metricsReceiver.self.send(histogramMessage)
+    metricsReceiver.self.askWithRetry(histogramMessage)
 
     eventually {
       metricsReceiver.metrics should contain key histogramName
       metricsReceiver.metrics.get(histogramName).get.asInstanceOf[Histogram].getCount shouldBe 1
     }
 
-    metricsReceiver.self.send(histogramMessage)
+    metricsReceiver.self.askWithRetry(histogramMessage)
 
     eventually {
       metricsReceiver.metrics.get(histogramName).get.asInstanceOf[Histogram].getCount shouldBe 2
@@ -153,14 +153,14 @@ class MetricsReceiverTest extends FlatSpec with Matchers with BeforeAndAfter wit
   it should "handle MeterMessage correctly" in {
     val meterName = "Meter"
     val meterMessage = MeterMessage(meterName, 1)
-    metricsReceiver.self.send(meterMessage)
+    metricsReceiver.self.askWithRetry(meterMessage)
 
     eventually {
       metricsReceiver.metrics should contain key meterName
       metricsReceiver.metrics.get(meterName).get.asInstanceOf[Meter].getCount shouldBe 1
     }
 
-    metricsReceiver.self.send(meterMessage)
+    metricsReceiver.self.askWithRetry(meterMessage)
 
     eventually {
       metricsReceiver.metrics.get(meterName).get.asInstanceOf[Meter].getCount shouldBe 2
@@ -170,14 +170,14 @@ class MetricsReceiverTest extends FlatSpec with Matchers with BeforeAndAfter wit
   it should "handle TimerMessage correctly" in {
     val timerName = "Timer"
     val timerMessage = TimerMessage(timerName, 1, ReservoirClass.ExponentiallyDecaying, ClockClass.UserTime)
-    metricsReceiver.self.send(timerMessage)
+    metricsReceiver.self.askWithRetry(timerMessage)
 
     eventually {
       metricsReceiver.metrics should contain key timerName
       metricsReceiver.metrics.get(timerName).get.asInstanceOf[Timer].getCount shouldBe 1
     }
 
-    metricsReceiver.self.send(timerMessage)
+    metricsReceiver.self.askWithRetry(timerMessage)
 
     eventually {
       metricsReceiver.metrics.get(timerName).get.asInstanceOf[Timer].getCount shouldBe 2
@@ -186,14 +186,14 @@ class MetricsReceiverTest extends FlatSpec with Matchers with BeforeAndAfter wit
 
   it should "handle GaugeMessage correctly" in {
     val gaugeName = "Gauge"
-    metricsReceiver.self.send(GaugeMessage(gaugeName, 1))
+    metricsReceiver.self.askWithRetry(GaugeMessage(gaugeName, 1))
 
     eventually {
       metricsReceiver.metrics should contain key gaugeName
       metricsReceiver.metrics.get(gaugeName).get.asInstanceOf[Gauge[AnyVal]].getValue shouldBe 1
     }
 
-    metricsReceiver.self.send(GaugeMessage(gaugeName, 2))
+    metricsReceiver.self.askWithRetry(GaugeMessage(gaugeName, 2))
 
     eventually {
       metricsReceiver.metrics.get(gaugeName).get.asInstanceOf[Gauge[AnyVal]].getValue shouldBe 2

--- a/src/test/scala/org/apache/spark/groupon/metrics/MetricsReceiverTest.scala
+++ b/src/test/scala/org/apache/spark/groupon/metrics/MetricsReceiverTest.scala
@@ -119,14 +119,14 @@ class MetricsReceiverTest extends FlatSpec with Matchers with BeforeAndAfter wit
   "receive" should "handle CounterMessage correctly" in {
     val counterName = "Counter"
     val counterMessage = CounterMessage(counterName, 1)
-    metricsReceiver.self.askWithRetry(counterMessage)
+    metricsReceiver.self.askWithRetry[Any](counterMessage)
 
     eventually {
       metricsReceiver.metrics should contain key counterName
       metricsReceiver.metrics.get(counterName).get.asInstanceOf[Counter].getCount shouldBe 1
     }
 
-    metricsReceiver.self.askWithRetry(counterMessage)
+    metricsReceiver.self.askWithRetry[Any](counterMessage)
 
     eventually {
       metricsReceiver.metrics.get(counterName).get.asInstanceOf[Counter].getCount shouldBe 2
@@ -136,14 +136,14 @@ class MetricsReceiverTest extends FlatSpec with Matchers with BeforeAndAfter wit
   it should "handle HistogramMessage correctly" in {
     val histogramName = "Histogram"
     val histogramMessage = HistogramMessage(histogramName, 1, ReservoirClass.ExponentiallyDecaying)
-    metricsReceiver.self.askWithRetry(histogramMessage)
+    metricsReceiver.self.askWithRetry[Any](histogramMessage)
 
     eventually {
       metricsReceiver.metrics should contain key histogramName
       metricsReceiver.metrics.get(histogramName).get.asInstanceOf[Histogram].getCount shouldBe 1
     }
 
-    metricsReceiver.self.askWithRetry(histogramMessage)
+    metricsReceiver.self.askWithRetry[Any](histogramMessage)
 
     eventually {
       metricsReceiver.metrics.get(histogramName).get.asInstanceOf[Histogram].getCount shouldBe 2
@@ -153,14 +153,14 @@ class MetricsReceiverTest extends FlatSpec with Matchers with BeforeAndAfter wit
   it should "handle MeterMessage correctly" in {
     val meterName = "Meter"
     val meterMessage = MeterMessage(meterName, 1)
-    metricsReceiver.self.askWithRetry(meterMessage)
+    metricsReceiver.self.askWithRetry[Any](meterMessage)
 
     eventually {
       metricsReceiver.metrics should contain key meterName
       metricsReceiver.metrics.get(meterName).get.asInstanceOf[Meter].getCount shouldBe 1
     }
 
-    metricsReceiver.self.askWithRetry(meterMessage)
+    metricsReceiver.self.askWithRetry[Any](meterMessage)
 
     eventually {
       metricsReceiver.metrics.get(meterName).get.asInstanceOf[Meter].getCount shouldBe 2
@@ -170,14 +170,14 @@ class MetricsReceiverTest extends FlatSpec with Matchers with BeforeAndAfter wit
   it should "handle TimerMessage correctly" in {
     val timerName = "Timer"
     val timerMessage = TimerMessage(timerName, 1, ReservoirClass.ExponentiallyDecaying, ClockClass.UserTime)
-    metricsReceiver.self.askWithRetry(timerMessage)
+    metricsReceiver.self.askWithRetry[Any](timerMessage)
 
     eventually {
       metricsReceiver.metrics should contain key timerName
       metricsReceiver.metrics.get(timerName).get.asInstanceOf[Timer].getCount shouldBe 1
     }
 
-    metricsReceiver.self.askWithRetry(timerMessage)
+    metricsReceiver.self.askWithRetry[Any](timerMessage)
 
     eventually {
       metricsReceiver.metrics.get(timerName).get.asInstanceOf[Timer].getCount shouldBe 2
@@ -186,14 +186,14 @@ class MetricsReceiverTest extends FlatSpec with Matchers with BeforeAndAfter wit
 
   it should "handle GaugeMessage correctly" in {
     val gaugeName = "Gauge"
-    metricsReceiver.self.askWithRetry(GaugeMessage(gaugeName, 1))
+    metricsReceiver.self.askWithRetry[Any](GaugeMessage(gaugeName, 1))
 
     eventually {
       metricsReceiver.metrics should contain key gaugeName
       metricsReceiver.metrics.get(gaugeName).get.asInstanceOf[Gauge[AnyVal]].getValue shouldBe 1
     }
 
-    metricsReceiver.self.askWithRetry(GaugeMessage(gaugeName, 2))
+    metricsReceiver.self.askWithRetry[Any](GaugeMessage(gaugeName, 2))
 
     eventually {
       metricsReceiver.metrics.get(gaugeName).get.asInstanceOf[Gauge[AnyVal]].getValue shouldBe 2

--- a/src/test/scala/org/apache/spark/groupon/metrics/util/TestMetricsRpcEndpoint.scala
+++ b/src/test/scala/org/apache/spark/groupon/metrics/util/TestMetricsRpcEndpoint.scala
@@ -33,14 +33,15 @@
 package org.apache.spark.groupon.metrics.util
 
 import org.apache.spark.groupon.metrics._
-import org.apache.spark.rpc.{ThreadSafeRpcEndpoint, RpcEnv}
+import org.apache.spark.rpc.{RpcCallContext, RpcEnv, ThreadSafeRpcEndpoint}
 
 class TestMetricsRpcEndpoint(override val rpcEnv: RpcEnv) extends ThreadSafeRpcEndpoint {
   val metricStore = new scala.collection.mutable.ArrayBuffer[MetricMessage]()
 
-  override def receive: PartialFunction[Any, Unit] = {
+  override def receiveAndReply(context: RpcCallContext): PartialFunction[Any, Unit] = {
     case msg: MetricMessage => {
       metricStore += msg
+      context.reply("1")
     }
   }
 


### PR DESCRIPTION
Current implementation uses askWithRetry.

This is configurable by 
`spark.rpc.numRetries`
`spark.rpc.retry.wait`
`spark.rpc.askTimeout` 
